### PR TITLE
Add missing separator tokens

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -6,7 +6,7 @@ export const jsonHighlighting = styleTags({
   "True False": t.bool,
   PropertyName: t.propertyName,
   Null: t.null,
-  ",": t.separator,
+  ", :": t.separator,
   "[ ]": t.squareBracket,
   "{ }": t.brace
 })

--- a/src/json.grammar
+++ b/src/json.grammar
@@ -27,7 +27,7 @@ PropertyName[isolate] { string }
 
   whitespace { $[ \n\r\t] }
 
-  "{" "}" "[" "]"
+  "{" "}" "[" "]" "," ":"
 }
 
 @skip { whitespace }


### PR DESCRIPTION
Add `","` and `":"` to `@tokens`  to make them be highlighted correctly as t.separator